### PR TITLE
Improve float formatting in `interpret_print` for cleaner output

### DIFF
--- a/FlavorLang/interpreter/interpreter.c
+++ b/FlavorLang/interpreter/interpreter.c
@@ -515,7 +515,16 @@ void interpret_print(ASTNode *node, Environment *env)
         switch (value.type)
         {
         case TYPE_FLOAT:
-            printf("%f", value.data.floating_point);
+            if ((int)value.data.floating_point == value.data.floating_point)
+            {
+                // Value is effectively an integer, force one decimal place
+                printf("%.1f", value.data.floating_point);
+            }
+            else
+            {
+                // Otherwise, use `%g` for trimming unnecessary zeroes
+                printf("%g", value.data.floating_point);
+            }
             break;
         case TYPE_INTEGER:
             printf("%d", value.data.integer);


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2024-12-27 at 01 10 55" src="https://github.com/user-attachments/assets/cf43c3e3-9d15-44de-97cf-fc80fe81eb32" />


- Updated `interpret_print()` to remove unnecessary trailing zeroes from floats and ensure clarity
- Floats with no fractional part (e.g., `3.0`) use `%.1f`, while other floats (e.g., `-3.14`) use `%g`


Closes #73