### PR TITLE
Issue 88: Update README.md — Fixed boolean capitalization in Data Types section of `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,19 +154,19 @@ The `--debug` flag is really useful for understanding how FlavorLang is executin
 
 ## Data Types
 
-| Data Type | Syntax Example    | Capacity/Range                                                                                 | Implemented? |
-| --------- | ----------------- | ---------------------------------------------------------------------------------------------- | ------------ |
-| `string`  | `"Hello, world!"` | Size depends on system memory and encoding (e.g., UTF-8). Null-terminated, variable length.    | ✅           |
-| `float`   | `3.14`            | `float` (32-bit): ±3.4E±38. `double` (64-bit): ±1.8E±308.                                      | ✅           |
-| `integer` | `42`              | Typically −2,147,483,648 to 2,147,483,647 (32-bit). Larger range for 64-bit.                   | ✅           |
-| `boolean` | `true` / `false`  | `1` for true, `0` for false. Typically stored as 1 byte, though this can vary by architecture. | ✅           |
+| Data Type | Syntax Example    | Capacity/Range                                                                                     | Implemented? |
+| --------- | ----------------- | -------------------------------------------------------------------------------------------------- | ------------ |
+| `string`  | `"Hello, world!"` | Size depends on system memory and encoding (e.g., UTF-8). Null-terminated, variable length.        | ✅           |
+| `float`   | `3.14`            | `float` (32-bit): ±3.4E±38. `double` (64-bit): ±1.8E±308.                                          | ✅           |
+| `integer` | `42`              | Typically −2,147,483,648 to 2,147,483,647 (32-bit). Larger range for 64-bit.                       | ✅           |
+| `boolean` | `True` / `False`  | `1` for `True`, `0` for `False`. Typically stored as 1 byte, though this can vary by architecture. | ✅           |
 
 ### Explanation
 
 - **string**: In C, strings are null-terminated arrays of characters. The length is limited by system memory and encoding. For example, in UTF-8 encoding, a string can take varying amounts of space per character depending on the character set.
 - **float**: The `float` type is a 32-bit floating-point number, typically with a range of ±3.4E±38. If you're using `double` (64-bit), it has a range of ±1.8E±308. In the `LiteralNode` struct, we are using `double` for floating-point literals, which offers higher precision.
 - **integer**: The typical range for an `integer` (32-bit) is from −2,147,483,648 to 2,147,483,647. For larger integers, the range increases with a 64-bit integer type (e.g., ±9.2E18).
-- **boolean**: Booleans are typically stored as `1` (true) and `0` (false). While they are logically 1-bit, they are typically stored in 1 byte, though this can vary based on the system's architecture.
+- **boolean**: Booleans are typically stored as `1` (`True`) and `0` (`False`). While they are logically 1-bit, they are typically stored in 1 byte, though this can vary based on the system's architecture.
 
 ---
 


### PR DESCRIPTION
Closes #88