### PR TITLE
Fix: Incorrect use of `flavorlang` instead of `flavor` in install scripts

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -4,12 +4,12 @@
 set -e
 
 # Set execute permissions
-chmod +x flavorlang
+chmod +x flavor
 
 # Move to /usr/local/bin for easier access
-echo "Moving flavorlang to /usr/local/bin/"
-sudo mv flavorlang /usr/local/bin/
+echo "Moving flavor to /usr/local/bin/"
+sudo mv flavor /usr/local/bin/
 
 # Run the executable
 echo "Running FlavorLang interpreter..."
-flavorlang --about
+flavor --about

--- a/scripts/install_ubuntu.sh
+++ b/scripts/install_ubuntu.sh
@@ -4,12 +4,12 @@
 set -e
 
 # Set execute permissions
-chmod +x flavorlang
+chmod +x flavor
 
 # Move to /usr/local/bin for easier access
-echo "Moving flavorlang to /usr/local/bin/"
-sudo mv flavorlang /usr/local/bin/
+echo "Moving flavor to /usr/local/bin/"
+sudo mv flavor /usr/local/bin/
 
 # Run the executable
 echo "Running FlavorLang interpreter..."
-flavorlang --about
+flavor --about


### PR DESCRIPTION
Closes #154