### PR TITLE
Issue 222: Fix — Zsh tab autocomplete for `flavor` command options

### DIFF
--- a/scripts/autocomplete/zsh_completion.sh
+++ b/scripts/autocomplete/zsh_completion.sh
@@ -1,6 +1,16 @@
 #compdef flavor
+
 _flavor_completions() {
     local -a opts
-    opts=(--help --github --about --debug --minify --make-plugin)
-    _describe -t commands 'flavor commands' opts
+    opts=(
+        '--help:Show help information'
+        '--github:Open GitHub repository'
+        '--about:Show FlavorLang details'
+        '--debug:Enable debug mode'
+        '--minify:Minify a script'
+        '--make-plugin:Compile a shared library plugin'
+    )
+    _describe 'flavor options' opts
 }
+
+_flavor_completions "$@"


### PR DESCRIPTION
- Updated `zsh_completion.sh` to include option descriptions for better usability.
- Ensured correct integration with Zsh’s completion system by invoking `_flavor_completions "$@"`.
- Verified functionality for `flavor --[TAB]` to display options and descriptions.

Closes #222 