### PR TITLE
Issue 222: Fix — Automated Zsh & Bash autocomplete setup in install scripts

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -58,6 +58,12 @@ elif [[ "$USER_SHELL" == "zsh" ]]; then
         echo -e "[${GREEN}${BOLD}SUCCESS${RESET}] Added 'fpath' configuration to ~/.zshrc."
     fi
 
+    # Ensure autoload and compinit are configured
+    if ! grep -q "autoload -Uz compinit && compinit" "$HOME/.zshrc"; then
+        echo "autoload -Uz compinit && compinit" >> "$HOME/.zshrc"
+        echo -e "[${GREEN}${BOLD}SUCCESS${RESET}] Added 'compinit' initialization to ~/.zshrc."
+    fi
+
     echo -e "[${GREEN}${BOLD}SUCCESS${RESET}] Zsh completion script installed to:"
     echo "   $COMPLETION_FILE"
     echo ""

--- a/scripts/install_ubuntu.sh
+++ b/scripts/install_ubuntu.sh
@@ -58,6 +58,12 @@ elif [[ "$USER_SHELL" == "zsh" ]]; then
         echo -e "[${GREEN}${BOLD}SUCCESS${RESET}] Added 'fpath' configuration to ~/.zshrc."
     fi
 
+    # Ensure autoload and compinit are configured
+    if ! grep -q "autoload -Uz compinit && compinit" "$HOME/.zshrc"; then
+        echo "autoload -Uz compinit && compinit" >> "$HOME/.zshrc"
+        echo -e "[${GREEN}${BOLD}SUCCESS${RESET}] Added 'compinit' initialization to ~/.zshrc."
+    fi
+
     echo -e "[${GREEN}${BOLD}SUCCESS${RESET}] Zsh completion script installed to:"
     echo "   $COMPLETION_FILE"
     echo ""


### PR DESCRIPTION
- Updated `install_macos.sh` & `install_ubuntu.sh` to handle Zsh & Bash autocompletion setup automatically.
- Ensured Zsh scripts add `fpath` & `compinit` initialization to `.zshrc` if not present.

Closes #222 