### PR TITLE
Issue 240: Add `floor`, `ceil`, `round`, and `abs` to the Standard Library

### DIFF
--- a/docs/standard_library.md
+++ b/docs/standard_library.md
@@ -22,6 +22,11 @@ The FlavorLang Standard Library provides a comprehensive set of built-in functio
      - [`random() → float`](#random--float)
      - [`random(max) → int`](#randommax--int)
      - [`random(min, max) → int`](#randommin-max--int)
+   - [Math Functions](#math-functions)
+     - [`floor(value) → int`](#floorvalue--int)
+     - [`ceil(value) → int`](#ceilvalue--int)
+     - [`round(value) → int`](#roundvalue--int)
+     - [`abs(value) → numeric`](#absvalue--numeric)
    - [Time Operations](#time-operations)
      - [`get_time() → int`](#get_time--int)
    - [File Operations](#file-operations)
@@ -193,6 +198,86 @@ random();       # 0.0 to 1.0
 random(10);     # 0 to 9
 random(5, 10);  # 5 to 9
 ```
+
+### Math Functions
+
+#### `floor(value) → int`
+
+Rounds a floating-point number down to the nearest integer.
+
+##### Parameters
+
+- **value:** A floating-point number.
+
+##### Returns
+
+- **int:** The largest integer less than or equal to value.
+
+##### Examples
+
+```py
+serve(floor(3.8));  # Output: 3
+serve(floor(-2.4)); # Output: -3
+```
+
+#### `ceil(value) → int`
+
+Rounds a floating-point number up to the nearest integer.
+
+##### Parameters
+
+- **value:** A floating-point number.
+
+##### Returns
+
+- **int:** The smallest integer greater than or equal to value.
+
+##### Examples
+
+```py
+serve(ceil(3.2));   # Output: 4
+serve(ceil(-2.8));  # Output: -2
+```
+
+#### `round(value) → int`
+
+Rounds a floating-point number to the nearest integer.
+
+##### Parameters
+
+- **value:** A floating-point number.
+
+##### Returns
+
+- **int:** The nearest integer to value.
+
+##### Examples
+
+```
+serve(round(3.5));   # Output: 4
+serve(round(-2.5));  # Output: -2
+```
+
+#### `abs(value) → numeric`
+
+Returns the absolute value of a number.
+
+##### Parameters
+
+- **numeric:** An integer or floating-point number.
+
+##### Returns
+
+- **numeric:** The absolute value of the input.
+
+##### Examples
+
+```py
+serve(abs(-42));   # Output: 42
+serve(abs(-3.8));  # Output: 3.8
+```
+
+###
 
 ### Time Operations
 

--- a/src/interpreter/builtins.c
+++ b/src/interpreter/builtins.c
@@ -1042,3 +1042,76 @@ InterpretResult builtin_cimport(ASTNode *node, Environment *env) {
     ret.data.integer = 0;
     return make_result(ret, false, false);
 }
+
+InterpretResult builtin_floor(ASTNode *node, Environment *env) {
+    // Expect exactly one numeric argument
+    FLOAT_SIZE value;
+    ArgumentSpec specs[1];
+    specs[0].type = ARG_TYPE_NUMERIC;
+    specs[0].out_ptr = &value;
+
+    InterpretResult args_res =
+        interpret_arguments(node->function_call.arguments, env, 1, specs);
+    if (args_res.is_error) {
+        return args_res;
+    }
+
+    LiteralValue result;
+    result.type = TYPE_FLOAT;
+    result.data.floating_point = floor(value);
+    return make_result(result, false, false);
+}
+
+InterpretResult builtin_ceil(ASTNode *node, Environment *env) {
+    FLOAT_SIZE value;
+    ArgumentSpec specs[1];
+    specs[0].type = ARG_TYPE_NUMERIC;
+    specs[0].out_ptr = &value;
+
+    InterpretResult args_res =
+        interpret_arguments(node->function_call.arguments, env, 1, specs);
+    if (args_res.is_error) {
+        return args_res;
+    }
+
+    LiteralValue result;
+    result.type = TYPE_FLOAT;
+    result.data.floating_point = ceil(value);
+    return make_result(result, false, false);
+}
+
+InterpretResult builtin_round(ASTNode *node, Environment *env) {
+    FLOAT_SIZE value;
+    ArgumentSpec specs[1];
+    specs[0].type = ARG_TYPE_NUMERIC;
+    specs[0].out_ptr = &value;
+
+    InterpretResult args_res =
+        interpret_arguments(node->function_call.arguments, env, 1, specs);
+    if (args_res.is_error) {
+        return args_res;
+    }
+
+    LiteralValue result;
+    result.type = TYPE_FLOAT;
+    result.data.floating_point = round(value);
+    return make_result(result, false, false);
+}
+
+InterpretResult builtin_abs(ASTNode *node, Environment *env) {
+    FLOAT_SIZE value;
+    ArgumentSpec specs[1];
+    specs[0].type = ARG_TYPE_NUMERIC;
+    specs[0].out_ptr = &value;
+
+    InterpretResult args_res =
+        interpret_arguments(node->function_call.arguments, env, 1, specs);
+    if (args_res.is_error) {
+        return args_res;
+    }
+
+    LiteralValue result;
+    result.type = TYPE_FLOAT;
+    result.data.floating_point = fabs(value);
+    return make_result(result, false, false);
+}

--- a/src/interpreter/builtins.h
+++ b/src/interpreter/builtins.h
@@ -5,6 +5,7 @@
 #include "../shared/ast_types.h"
 #include "interpreter_types.h"
 #include "utils.h"
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,6 +38,10 @@ InterpretResult builtin_file_append(ASTNode *node, Environment *env);
 InterpretResult builtin_length(ASTNode *node, Environment *env);
 InterpretResult builtin_sleep(ASTNode *node, Environment *env);
 InterpretResult builtin_cimport(ASTNode *node, Environment *env);
+InterpretResult builtin_floor(ASTNode *node, Environment *env);
+InterpretResult builtin_ceil(ASTNode *node, Environment *env);
+InterpretResult builtin_round(ASTNode *node, Environment *env);
+InterpretResult builtin_abs(ASTNode *node, Environment *env);
 
 // Helpers
 bool literal_type_matches_arg_type(LiteralType lit_type, ArgType arg_type);

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -1642,6 +1642,14 @@ InterpretResult interpret_function_call(ASTNode *node, Environment *env) {
             return builtin_length(node, env);
         } else if (strcmp(func->name, "sleep") == 0) {
             return builtin_sleep(node, env);
+        } else if (strcmp(func->name, "floor") == 0) {
+            return builtin_floor(node, env);
+        } else if (strcmp(func->name, "ceil") == 0) {
+            return builtin_ceil(node, env);
+        } else if (strcmp(func->name, "round") == 0) {
+            return builtin_round(node, env);
+        } else if (strcmp(func->name, "abs") == 0) {
+            return builtin_abs(node, env);
         } else {
             return raise_error("Unknown built-in function `%s`\n", func->name);
         }

--- a/src/interpreter/utils.c
+++ b/src/interpreter/utils.c
@@ -73,7 +73,8 @@ void initialize_all_builtin_functions(Environment *env) {
     const char *builtin_functions[] = {
         "string",       "float",  "int",      "sample",     "serve",
         "burn",         "random", "get_time", "taste_file", "plate_file",
-        "garnish_file", "length", "sleep",    "cimport"};
+        "garnish_file", "length", "sleep",    "cimport",    "floor",
+        "ceil",         "round",  "abs"};
 
     for (size_t i = 0;
          i < sizeof(builtin_functions) / sizeof(builtin_functions[0]); i++) {

--- a/src/tests/misc/L.flv
+++ b/src/tests/misc/L.flv
@@ -1,0 +1,4 @@
+serve("floor(3.7) =", floor(3.7));
+serve("ceil(3.3) =", ceil(3.3));
+serve("round(3.5) =", round(3.5));
+serve("abs(-42) =", abs(-42));

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "flavorlang-vscode",
   "displayName": "FlavorLang Support",
   "description": "Syntax highlighting for FlavorLang programming language.",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "publisher": "KennyOliver",
   "repository": {
     "type": "git",

--- a/vscode-extension/syntaxes/flavorlang.tmLanguage.json
+++ b/vscode-extension/syntaxes/flavorlang.tmLanguage.json
@@ -40,7 +40,7 @@
       "patterns": [
         {
           "name": "keyword.control.flavorlang",
-          "match": "\\b(let|const|if|elif|else|for|in|while|create|burn|deliver|check|is|rescue|try|rescue|finish|break|continue|import|export|cimport)\\b"
+          "match": "\\b(let|const|if|elif|else|for|in|while|create|burn|deliver|check|is|rescue|try|rescue|finish|break|continue|import|export|cimport|floor|ceil|round|abs)\\b"
         },
         {
           "name": "keyword.other.flavorlang",


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2025-01-19 at 21 48 20" src="https://github.com/user-attachments/assets/9b003258-0e1e-44c0-ad14-8d061ce1975f" />


Closes #240 